### PR TITLE
Append cache

### DIFF
--- a/backbone.cachingsync.js
+++ b/backbone.cachingsync.js
@@ -64,6 +64,15 @@
 
             wp = wrapped('read', collection, options).done(function (models) {
                 _.each(models, function (model) { burry.set(model.id, model); });
+                // Implementing collections can optionally append new model ids
+                // to the cache instead of rewriting this set each time.
+                if (options.cache_append) {
+                  ids = _.union(ids, _.pluck(models, 'id'));
+                  burry.set('__ids__', ids);
+                }
+                else {
+                  burry.set('__ids__', _.pluck(models, 'id'));
+                }
                 // Respect the fetch "update" option.
                 if (options.update) {
                   collection.update(models, options)


### PR DESCRIPTION
For cases like paging interfaces where you're doing many small fetches. The cache should be able to hold all of them.
