### PR TITLE
Remove nulls in __ids__

### DIFF
--- a/backbone.cachingsync.js
+++ b/backbone.cachingsync.js
@@ -61,6 +61,9 @@
             var ids = burry.get('__ids__'),
                 d = $.Deferred(),
                 wp;
+                
+            // Filter out any nulls which creep in.
+            ids = _.filter(ids, function(id) { return !_.isNull(id) });
 
             wp = wrapped('read', collection, options).done(function (models) {
                 _.each(models, function (model) { burry.set(model.id, model); });


### PR DESCRIPTION
Not sure why this happens but occassinally there'll be a null id saved which subsequently throws an error on line 79. Filter those out.
