### PR TITLE
Added support for jQuery in no conflict mode

### DIFF
--- a/backbone.cachingsync.js
+++ b/backbone.cachingsync.js
@@ -13,7 +13,7 @@
         });
     } else {
         // Browser globals
-        root.Backbone.cachingSync = factory(root.$, root._, root.Backbone, root.Burry);
+        root.Backbone.cachingSync = factory(root.jQuery, root._, root.Backbone, root.Burry);
     }
 }(this, function ($, _, Backbone, Burry) {
 


### PR DESCRIPTION
We use jQuery and prototype.js on some of our sites so root.$ doesn't resolve to jQuery as it should. This change doesn't impact any sites that don't use no conflict while adding support for sites that do.